### PR TITLE
修改文章《zsh下配置命令的别名》的细节

### DIFF
--- a/_posts/2017-3-28-zshrc-alias.md
+++ b/_posts/2017-3-28-zshrc-alias.md
@@ -9,11 +9,15 @@ share: true
 ---
 > Ubuntu版本：16.04 LTS
 
-### `Ctrl + Alt + T`打开终端。
-### 输入`sudo vim ~/.zshrc`并回车。
-### 添加命令别名
+### 1.打开终端
+使用`Ctrl + Alt + T`打开终端。
+### 2.打开zsh配置文件
+输入`sudo vim ~/.zshrc`并回车。
+### 2.添加命令别名
 例：`alias ssopen='sslocal -c ~/shadowsocks.json -d start'`
 
 之后按ESC键，键入:wq并回车，将会保存文件。
-### 再输入`source ~/.zshrc`并回车，这步会将配置文件生效。
-### 之后输入`ssopen`并回车的效果等于输入`sslocal -c ~/shadowsocks.json -d start`并回车。
+### 3.使配置文件生效
+输入`source ~/.zshrc`并回车，这步会将配置文件生效。
+### 4.使用命令的别名
+输入`ssopen`命令的效果等于输入`sslocal -c ~/shadowsocks.json -d start`。


### PR DESCRIPTION
1.修改文章的排版和内容，使其更美观和实用。